### PR TITLE
fix: Add port configuration to database settings

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -3,6 +3,7 @@
 // Database configuration
 $config['database'] = [
     'host' => getenv('DB_HOST') ?: 'localhost',
+    'port' => getenv('DB_PORT') ?: '3306',
     'database' => getenv('DB_NAME') ?: 'numok_app',
     'username' => getenv('DB_USER') ?: 'numok_user',
     'password' => getenv('DB_PASS') ?: 'change_me_app_2025',

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -20,8 +20,9 @@ class Database {
         if (self::$instance === null) {
             try {
                 $dsn = sprintf(
-                    "mysql:host=%s;dbname=%s;charset=utf8mb4",
+                    "mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4",
                     self::$config['host'],
+                    self::$config['port'],
                     self::$config['database']
                 );
 


### PR DESCRIPTION
This pull request introduces support for specifying the database port in the application's configuration. This allows the application to connect to MySQL instances running on non-default ports, increasing flexibility for different deployment environments.

**Configuration updates:**

* Added a `port` entry to the database configuration in `config/config.example.php`, which reads from the `DB_PORT` environment variable or defaults to `3306`.

**Database connection logic:**

* Updated the DSN string in `Database.php` to include the port value when creating a new PDO instance, ensuring the application connects to the correct database port.

Fixes #12 